### PR TITLE
👔 에러 코드 정의, 권한 & 이름 조회 API 개발

### DIFF
--- a/src/main/java/com/zipple/common/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/zipple/common/auth/jwt/JwtFilter.java
@@ -1,10 +1,13 @@
 package com.zipple.common.auth.jwt;
 
+import com.zipple.common.exception.ErrorCode;
+import com.zipple.common.exception.custom.TokenInvalidException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -12,26 +15,61 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.GenericFilterBean;
 
 import java.io.IOException;
+import java.util.List;
 
 @RequiredArgsConstructor
 public class JwtFilter extends GenericFilterBean {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private static final List<String> SWAGGER_WHITELIST = List.of(
+            "/swagger-ui/",
+            "/v3/api-docs",
+            "/swagger-resources",
+            "/webjars/",
+            "/api/auth/kakao",
+            "/api/v1/main/"
+    );
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+        String requestURI = httpRequest.getRequestURI();
+
+        if (SWAGGER_WHITELIST.stream().anyMatch(requestURI::startsWith)) {
+            chain.doFilter(request, response);
+            return;
+        }
         String token = resolveToken((HttpServletRequest) request);
-        if (token != null && jwtTokenProvider.validateToken(token)) {
+
+        try {
+            if (token == null || !jwtTokenProvider.validateToken(token)) {
+                throw new TokenInvalidException();
+            }
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (TokenInvalidException e) {
+            handleException(httpResponse, e.getErrorCode());
+            return;
         }
+
         chain.doFilter(request, response);
     }
+
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
             return bearerToken.substring(7);
         }
         return null;
+    }
+
+    private void handleException(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType("application/json; charset=UTF-8");
+        response.getWriter().write(String.format("{\"status\": %d, \"errorCode\": \"%s\", \"message\": \"%s\"}",
+                errorCode.getStatus().value(),
+                errorCode.getCode(),
+                errorCode.getMessage()));
     }
 }

--- a/src/main/java/com/zipple/common/auth/security/SecurityConfig.java
+++ b/src/main/java/com/zipple/common/auth/security/SecurityConfig.java
@@ -38,35 +38,32 @@ public class SecurityConfig {
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
                 .authorizeHttpRequests(
                         (authorize) -> {
-                            authorize.requestMatchers("/api/**", "/**").permitAll();
+                            authorize.requestMatchers("/api/**",
+                                    "/swagger-ui/**", // Swagger UI
+                                    "/v3/api-docs/**", // OpenAPI Docs
+                                    "/swagger-resources/**",
+                                    "/webjars/**",
+                                    "/api/auth/**",
+                                    "/api/v1/main/**").permitAll();
                             authorize.anyRequest().authenticated();
                         }
                 )
                 .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://34.201.103.186"));
+        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://34.201.103.186", "https://ziplanner-eruz.vercel.app"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "FETCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type"));
         configuration.setAllowCredentials(true);
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
-    }
-
-    @Bean
-    public FilterRegistrationBean<JwtFilter> jwtFilter() {
-        FilterRegistrationBean<JwtFilter> registrationBean = new FilterRegistrationBean<>();
-        registrationBean.setFilter(new JwtFilter(jwtTokenProvider));
-        registrationBean.addUrlPatterns("/api/**");
-        return registrationBean;
     }
 
     @Bean

--- a/src/main/java/com/zipple/common/exception/ApiException.java
+++ b/src/main/java/com/zipple/common/exception/ApiException.java
@@ -1,28 +1,13 @@
 package com.zipple.common.exception;
 
-public class ApiException extends Exception {
-  public ApiException() {
-    super();
-  }
+import lombok.Getter;
 
-  public ApiException(String message) {
-    super(message);
-  }
+@Getter
+public class ApiException extends RuntimeException {
+  private final ErrorCode errorCode;
 
-  public ApiException(String message, Throwable cause) {
-    super(message, cause);
-  }
-
-  public ApiException(Throwable cause) {
-    super(cause);
-  }
-
-  protected ApiException(
-          String message,
-          Throwable cause,
-          boolean enableSuppression,
-          boolean writableStackTrace
-  ) {
-    super(message, cause, enableSuppression, writableStackTrace);
+  public ApiException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
   }
 }

--- a/src/main/java/com/zipple/common/exception/ApiExceptionMsgHandler.java
+++ b/src/main/java/com/zipple/common/exception/ApiExceptionMsgHandler.java
@@ -1,4 +1,0 @@
-package com.zipple.common.exception;
-
-public class ApiExceptionMsgHandler {
-}

--- a/src/main/java/com/zipple/common/exception/ErrorCode.java
+++ b/src/main/java/com/zipple/common/exception/ErrorCode.java
@@ -1,0 +1,32 @@
+package com.zipple.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "4001", "잘못된 요청입니다."),
+    MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "4002", "필수 요청 값이 누락되었습니다."),
+    INVALID_FORMAT(HttpStatus.BAD_REQUEST, "4003", "입력 형식이 올바르지 않습니다."),
+
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "4011", "인증이 필요합니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "4012", "토큰이 만료되었습니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "4013", "유효하지 않은 토큰입니다."),
+
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "4031", "접근 권한이 없습니다."),
+
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "4041", "요청한 리소스를 찾을 수 없습니다."),
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5001", "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/zipple/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zipple/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.zipple.common.exception;
+
+import com.zipple.common.exception.custom.TokenInvalidException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    private ResponseEntity<Object> buildResponse(ErrorCode errorCode) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", errorCode.getStatus().value());
+        response.put("errorCode", errorCode.getCode());
+        response.put("message", errorCode.getMessage());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<Object> handleApiException(ApiException ex) {
+        return buildResponse(ex.getErrorCode());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleGenericException(Exception ex) {
+        return buildResponse(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/zipple/common/exception/custom/BadRequestException.java
+++ b/src/main/java/com/zipple/common/exception/custom/BadRequestException.java
@@ -1,0 +1,10 @@
+package com.zipple.common.exception.custom;
+
+import com.zipple.common.exception.ApiException;
+import com.zipple.common.exception.ErrorCode;
+
+public class BadRequestException extends ApiException {
+    public BadRequestException() {
+        super(ErrorCode.INVALID_REQUEST);
+    }
+}

--- a/src/main/java/com/zipple/common/exception/custom/EntityNotFoundException.java
+++ b/src/main/java/com/zipple/common/exception/custom/EntityNotFoundException.java
@@ -1,0 +1,10 @@
+package com.zipple.common.exception.custom;
+
+import com.zipple.common.exception.ApiException;
+import com.zipple.common.exception.ErrorCode;
+
+public class EntityNotFoundException extends ApiException {
+    public EntityNotFoundException() {
+        super(ErrorCode.ENTITY_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/zipple/common/exception/custom/ForbiddenException.java
+++ b/src/main/java/com/zipple/common/exception/custom/ForbiddenException.java
@@ -1,0 +1,10 @@
+package com.zipple.common.exception.custom;
+
+import com.zipple.common.exception.ApiException;
+import com.zipple.common.exception.ErrorCode;
+
+public class ForbiddenException extends ApiException {
+    public ForbiddenException() {
+        super(ErrorCode.ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/zipple/common/exception/custom/IllegalStateExceptionCustom.java
+++ b/src/main/java/com/zipple/common/exception/custom/IllegalStateExceptionCustom.java
@@ -1,0 +1,10 @@
+package com.zipple.common.exception.custom;
+
+import com.zipple.common.exception.ApiException;
+import com.zipple.common.exception.ErrorCode;
+
+public class IllegalStateExceptionCustom extends ApiException {
+    public IllegalStateExceptionCustom() {
+        super(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/zipple/common/exception/custom/TokenInvalidException.java
+++ b/src/main/java/com/zipple/common/exception/custom/TokenInvalidException.java
@@ -1,0 +1,10 @@
+package com.zipple.common.exception.custom;
+
+import com.zipple.common.exception.ApiException;
+import com.zipple.common.exception.ErrorCode;
+
+public class TokenInvalidException extends ApiException {
+    public TokenInvalidException() {
+        super(ErrorCode.TOKEN_INVALID);
+    }
+}

--- a/src/main/java/com/zipple/common/exception/custom/UnauthorizedException.java
+++ b/src/main/java/com/zipple/common/exception/custom/UnauthorizedException.java
@@ -1,0 +1,10 @@
+package com.zipple.common.exception.custom;
+
+import com.zipple.common.exception.ApiException;
+import com.zipple.common.exception.ErrorCode;
+
+public class UnauthorizedException extends ApiException {
+    public UnauthorizedException() {
+        super(ErrorCode.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/zipple/common/swagger/SwaggerConfig.java
+++ b/src/main/java/com/zipple/common/swagger/SwaggerConfig.java
@@ -28,11 +28,12 @@ public class SwaggerConfig {
                         .contact(new Contact()
                                 .name("Donghwi")
                                 .email("tnqlsdld0222@gmail.com")))
-                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME)) // 보안 스키마 적용
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
                 .components(new Components()
                         .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
                                 .type(SecurityScheme.Type.HTTP)
                                 .scheme("bearer")
+                                .description("bearer 자동 삽입")
                                 .bearerFormat("JWT")
                                 .in(SecurityScheme.In.HEADER)
                                 .name(SECURITY_SCHEME_NAME)));

--- a/src/main/java/com/zipple/common/utils/GetMember.java
+++ b/src/main/java/com/zipple/common/utils/GetMember.java
@@ -1,5 +1,6 @@
 package com.zipple.common.utils;
 
+import com.zipple.common.exception.custom.UnauthorizedException;
 import com.zipple.module.member.common.entity.User;
 import com.zipple.module.member.common.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,6 @@ public class GetMember {
                                 .getAuthentication()
                                 .getName()
                 )
-                .orElseThrow(() -> new IllegalStateException("다시 로그인 해주세요"));
+                .orElseThrow(UnauthorizedException::new);
     }
 }

--- a/src/main/java/com/zipple/module/like/entity/AgentLikeRepository.java
+++ b/src/main/java/com/zipple/module/like/entity/AgentLikeRepository.java
@@ -3,6 +3,8 @@ package com.zipple.module.like.entity;
 import com.zipple.module.member.common.entity.AgentUser;
 import com.zipple.module.member.common.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,4 +14,7 @@ public interface AgentLikeRepository extends JpaRepository<AgentLike, Long> {
     boolean existsByUserAndAgentUser(User user, AgentUser agentUser);
     void deleteByUserAndAgentUser(User user, AgentUser agentUser);
     long countByAgentUser(AgentUser agentUser);
+
+    @Query("SELECT COUNT(l) FROM AgentLike l WHERE l.agentUser.id = :agentUserId")
+    int countByAgentUserId(@Param("agentUserId") Long agentUserId);
 }

--- a/src/main/java/com/zipple/module/mainpage/MainPageController.java
+++ b/src/main/java/com/zipple/module/mainpage/MainPageController.java
@@ -12,10 +12,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "메인 화면")
 @RestController
@@ -25,12 +22,12 @@ public class MainPageController {
 
     private final MainPageService mainPageService;
 
-    @Operation(summary = "매칭 프로필 기본 화면")
+    @Operation(summary = "매칭 프로필 기본 화면", description = "페이징을 이용하여 중개사의 매칭 프로필을 조회합니다.")
     @GetMapping(value = "/matching")
     public ResponseEntity<MatchingResponse> getMatchingProfile(
-            @Parameter(name = "page")
+            @Parameter(name = "page", description = "페이지 번호", example = "0")
             @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @Parameter(name = "size")
+            @Parameter(name = "size", description = "페이지 크기", example = "9")
             @RequestParam(value = "size", defaultValue = "9") Integer size
     ) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
@@ -39,29 +36,27 @@ public class MainPageController {
     }
 
     @Operation(summary = "공인 중개사 상세 프로필")
-    @GetMapping(value = "/profile/detail")
+    @GetMapping(value = "/profile/detail/{agentId}")
     public ResponseEntity<DetailProfileResponse> getAgentDetailProfile(
-            @Parameter(name = "userId") @RequestParam(value = "userId") Long userId
+            @Parameter(name = "agentId", description = "중개사 상세 프로필에 대한 아이디")
+            @PathVariable(value = "agentId") Long agentId
     ) {
-        DetailProfileResponse detailProfileResponse = mainPageService.getAgentDetailProfile(userId);
+        DetailProfileResponse detailProfileResponse = mainPageService.getAgentDetailProfile(agentId);
         return ResponseEntity.ok(detailProfileResponse);
     }
 
     @Operation(summary = "공인 중개사 포트폴리오")
-    @GetMapping(value = "/portfolio")
+    @GetMapping(value = "/portfolio/{agentId}")
     public ResponseEntity<PortfolioPageResponse> getAgentPortfolio(
-            @Parameter(name = "userId")
-            @RequestParam(value = "userId") Long userId,
-            @Parameter(name = "agentType")
-            @RequestParam(value = "agentType") String agentType,
-            @Parameter(name = "page")
+            @Parameter(name = "agentId", description = "중개사 상세 프로필에 대한 아이디")
+            @PathVariable(value = "agentId") Long agentId,
+            @Parameter(name = "page", description = "페이지 번호", example = "0")
             @RequestParam(value = "page", defaultValue = "0") Integer page,
-            @Parameter(name = "size")
+            @Parameter(name = "size", description = "페이지 크기", example = "9")
             @RequestParam(value = "size", defaultValue = "9") Integer size
     ) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
-        AgentType type = AgentType.fromValue(agentType);
-        PortfolioPageResponse portfolios = mainPageService.getAgentPortfolio(userId, pageable, type);
+        PortfolioPageResponse portfolios = mainPageService.getAgentPortfolio(agentId, pageable);
 
         return ResponseEntity.ok(portfolios);
     }

--- a/src/main/java/com/zipple/module/member/OAuthController.java
+++ b/src/main/java/com/zipple/module/member/OAuthController.java
@@ -3,6 +3,7 @@ package com.zipple.module.member;
 import com.zipple.common.oauth.kakao.KakaoLoginParams;
 import com.zipple.module.member.oauth.model.AccessTokenRenewResponse;
 import com.zipple.module.member.oauth.model.AuthLoginResponse;
+import com.zipple.module.member.oauth.model.RoleResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -61,5 +62,12 @@ public class OAuthController {
     public ResponseEntity<AccessTokenRenewResponse> renewToken() {
         AccessTokenRenewResponse accessTokenRenewResponse = oAuthLoginService.renewAccessToken();
         return ResponseEntity.ok(accessTokenRenewResponse);
+    }
+
+    @Operation(summary = "권한, 이름 조회")
+    @GetMapping(value = "role")
+    public ResponseEntity<RoleResponse> role() {
+        RoleResponse roleResponse = oAuthLoginService.getRole();
+        return ResponseEntity.ok(roleResponse);
     }
 }

--- a/src/main/java/com/zipple/module/member/common/entity/AgentUser.java
+++ b/src/main/java/com/zipple/module/member/common/entity/AgentUser.java
@@ -29,6 +29,7 @@ public class AgentUser {
     private User user;
 
     @OneToMany(mappedBy = "agentUser", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<AgentLike> receivedLikes = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/zipple/module/member/common/entity/User.java
+++ b/src/main/java/com/zipple/module/member/common/entity/User.java
@@ -53,6 +53,7 @@ public class User implements UserDetails {
     private AgentUser agentUser;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<AgentLike> likedAgents = new ArrayList<>();
 
     @Override

--- a/src/main/java/com/zipple/module/member/email/EmailRegisterController.java
+++ b/src/main/java/com/zipple/module/member/email/EmailRegisterController.java
@@ -7,6 +7,7 @@ import com.zipple.module.member.email.model.EmailAgentRequest;
 import com.zipple.module.member.email.model.EmailGeneralRequest;
 import com.zipple.module.member.email.model.EmailLoginRequest;
 import com.zipple.module.member.email.model.EmailLoginResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -21,6 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 @Tag(name = "이메일 회원가입/로그인")
+@Hidden
 @CrossOrigin
 @RestController
 @RequestMapping(value = "/api/v1/email")

--- a/src/main/java/com/zipple/module/member/oauth/AfterOAuthController.java
+++ b/src/main/java/com/zipple/module/member/oauth/AfterOAuthController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zipple.module.member.oauth.model.AgentUserRequest;
 import com.zipple.module.member.oauth.model.GeneralUserRequest;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 @Tag(name = "소셜 로그인")
+@Hidden
 @RestController
 @RequestMapping("/api/v1/register")
 @RequiredArgsConstructor

--- a/src/main/java/com/zipple/module/member/oauth/model/RoleResponse.java
+++ b/src/main/java/com/zipple/module/member/oauth/model/RoleResponse.java
@@ -1,0 +1,15 @@
+package com.zipple.module.member.oauth.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoleResponse {
+
+    private String roleName;
+    private String nickname;
+
+}

--- a/src/main/java/com/zipple/module/mypage/agent/portfolio/PortfolioImageRepository.java
+++ b/src/main/java/com/zipple/module/mypage/agent/portfolio/PortfolioImageRepository.java
@@ -24,11 +24,13 @@ public interface PortfolioImageRepository extends JpaRepository<PortfolioImage, 
                                                           Pageable pageable,
                                                           @Param("agentType") AgentType agentType);
 
-    @Query("SELECT pi FROM PortfolioImage pi " +
+    @Query("SELECT new com.zipple.module.mypage.agent.portfolio.domain.PortfolioMainImage(" +
+            "p.id, p.title, pi.imageUrl, p.createdAt) " +
+            "FROM PortfolioImage pi " +
             "JOIN pi.portfolio p " +
             "WHERE p.user.id = :userId AND p.agentType = :agentType " +
             "AND pi.isMain = true")
     Page<PortfolioMainImage> findMainImagesByUserIdWithPagination(@Param("userId") Long userId,
-                                                                  Pageable pageable,
-                                                                  @Param("agentType") AgentType agentType);
+                                                                  @Param("agentType") AgentType agentType,
+                                                                  Pageable pageable);
 }

--- a/src/main/java/com/zipple/module/mypage/general/MyPageGeneralController.java
+++ b/src/main/java/com/zipple/module/mypage/general/MyPageGeneralController.java
@@ -2,6 +2,7 @@ package com.zipple.module.mypage.general;
 
 import com.zipple.module.mypage.general.domain.MyPageResponse;
 import com.zipple.module.mypage.general.domain.MyPageUpdateRequest;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,7 @@ public class MyPageGeneralController {
         return ResponseEntity.ok("정보 수정이 완료되었습니다.");
     }
 
+    @Hidden
     @Operation(
             summary = "일반 사용자 마이페이지 회원 탈퇴"
     )

--- a/src/main/java/com/zipple/module/review/ReviewController.java
+++ b/src/main/java/com/zipple/module/review/ReviewController.java
@@ -1,7 +1,7 @@
 package com.zipple.module.review;
 
-import com.zipple.module.mainpage.domain.ReviewResponse;
 import com.zipple.module.review.domain.ReviewRequest;
+import com.zipple.module.review.domain.ReviewResponse;
 import com.zipple.module.review.entity.Review;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -48,7 +48,7 @@ public class ReviewController {
 
     @Operation(summary = "공인중개사 리뷰 조회", description = "특정 공인중개사의 모든 리뷰를 조회합니다.")
     @GetMapping("/{agentId}")
-    public ResponseEntity<List<Review>> getReviewsByAgent(@PathVariable(value = "agentId") Long agentId) {
+    public ResponseEntity<List<ReviewResponse>> getReviewsByAgent(@PathVariable(value = "agentId") Long agentId) {
         return ResponseEntity.ok(reviewService.getReviewsByAgent(agentId));
     }
 

--- a/src/main/java/com/zipple/module/review/ReviewService.java
+++ b/src/main/java/com/zipple/module/review/ReviewService.java
@@ -5,6 +5,7 @@ import com.zipple.module.member.common.entity.AgentUser;
 import com.zipple.module.member.common.entity.User;
 import com.zipple.module.member.common.repository.AgentUserRepository;
 import com.zipple.module.review.domain.ReviewRequest;
+import com.zipple.module.review.domain.ReviewResponse;
 import com.zipple.module.review.entity.Review;
 import com.zipple.module.review.entity.ReviewRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -69,11 +71,20 @@ public class ReviewService {
     }
 
     @Transactional(readOnly = true)
-    public List<Review> getReviewsByAgent(Long agentId) {
+    public List<ReviewResponse> getReviewsByAgent(Long agentId) {
         AgentUser agentUser = agentUserRepository.findById(agentId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 공인중개사입니다."));
 
-        return reviewRepository.findByAgentUser(agentUser);
+        return reviewRepository.findByAgentUser(agentUser).stream()
+                .map(review -> ReviewResponse.builder()
+                        .reviewId(review.getId())
+                        .profileUrl(review.getUser().getProfile_image_url())
+                        .nickname(review.getUser().getNickname())
+                        .content(review.getContent())
+                        .createdAt(review.getCreatedAt().toString())
+                        .updatedAt(review.getUpdatedAt().toString())
+                        .build())
+                .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/zipple/module/review/domain/ReviewResponse.java
+++ b/src/main/java/com/zipple/module/review/domain/ReviewResponse.java
@@ -1,4 +1,4 @@
-package com.zipple.module.mainpage.domain;
+package com.zipple.module.review.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,14 +7,15 @@ import lombok.NoArgsConstructor;
 
 @Data
 @Builder
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class ReviewResponse {
 
-    private String userId;
-    private String nickname;
+    private Long reviewId;
     private String profileUrl;
-    private Integer startCount;
-    private String comments;
+    private String nickname;
+    private String content;
+    private String createdAt;
+    private String updatedAt;
 
 }

--- a/src/main/java/com/zipple/module/review/entity/ReviewRepository.java
+++ b/src/main/java/com/zipple/module/review/entity/ReviewRepository.java
@@ -16,4 +16,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("SELECT AVG(r.starCount) FROM Review r WHERE r.agentUser = :agentUser")
     Double findAverageStarCountByAgent(AgentUser agentUser);
 
+    int countByAgentUser(AgentUser agentUser);
+
 }


### PR DESCRIPTION
## 에러 코드 정의
- INVALID_REQUEST(HttpStatus.BAD_REQUEST, "4001", "잘못된 요청입니다."),
- MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "4002", "필수 요청 값이 누락되었습니다."),
- INVALID_FORMAT(HttpStatus.BAD_REQUEST, "4003", "입력 형식이 올바르지 않습니다."),
- UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "4011", "인증이 필요합니다."),
- TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "4012", "토큰이 만료되었습니다."),
- TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "4013", "유효하지 않은 토큰입니다."),
- ACCESS_DENIED(HttpStatus.FORBIDDEN, "4031", "접근 권한이 없습니다."),
- ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "4041", "요청한 리소스를 찾을 수 없습니다."),
- INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5001", "서버 내부 오류가 발생했습니다.");
## 권한, 이름 조회 
### 지속적으로 에러 코드 추가할 예정
